### PR TITLE
Implement Retry functionality into the fetch library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 *.cache
 composer.lock
+state.json

--- a/src/Client.php
+++ b/src/Client.php
@@ -32,6 +32,8 @@ class Client
     private string $userAgent = '';
     private int $maxRetries = 0;
     private int $retryDelay = 1000; // milliseconds
+
+    /** @var array<int> $retryStatusCodes */
     private array $retryStatusCodes = [500, 503];
 
     /**

--- a/src/Response.php
+++ b/src/Response.php
@@ -88,7 +88,7 @@ class Response
     public function json(): mixed
     {
         $data = \json_decode($this->body, true);
-        if($data === null) { // Throw an exception if the data is null
+        if ($data === null) { // Throw an exception if the data is null
             throw new \Exception('Error decoding JSON');
         }
         return $data;
@@ -101,7 +101,7 @@ class Response
     public function blob(): string
     {
         $bin = "";
-        for($i = 0, $j = strlen($this->body); $i < $j; $i++) {
+        for ($i = 0, $j = strlen($this->body); $i < $j; $i++) {
             $bin .= decbin(ord($this->body)) . " ";
         }
         return $bin;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -357,4 +357,47 @@ final class ClientTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * Test for retry functionality
+     * @return void
+     */
+    public function testRetry(): void
+    {
+        $client = new Client();
+        $client->setMaxRetries(3);
+        $client->setRetryDelay(1000);
+
+        $this->assertEquals(3, $client->getMaxRetries());
+        $this->assertEquals(1000, $client->getRetryDelay());
+
+        $res = $client->fetch('localhost:8000/mock-retry');
+        $this->assertEquals(200, $res->getStatusCode());
+
+        unlink(__DIR__ . '/state.json');
+
+        // Test if we get a 500 error if we go under the server's max retries
+        $client->setMaxRetries(1);
+        $res = $client->fetch('localhost:8000/mock-retry');
+        $this->assertEquals(503, $res->getStatusCode());
+
+        unlink(__DIR__ . '/state.json');
+    }
+
+    /**
+     * Test if the retry delay is working
+     * @return void
+     */
+    public function testRetryWithDelay(): void
+    {
+        $client = new Client();
+        $client->setMaxRetries(3);
+        $client->setRetryDelay(3000);
+        $now = microtime(true);
+
+        $res = $client->fetch('localhost:8000/mock-retry');
+        $this->assertGreaterThan($now + 3.0, microtime(true));
+        $this->assertEquals(200, $res->getStatusCode());
+        unlink(__DIR__ . '/state.json');
+    }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -400,4 +400,22 @@ final class ClientTest extends TestCase
         $this->assertEquals(200, $res->getStatusCode());
         unlink(__DIR__ . '/state.json');
     }
+
+    /**
+     * Test custom retry status codes
+     * @return void
+     */
+    public function testCustomRetryStatusCodes(): void
+    {
+        $client = new Client();
+        $client->setMaxRetries(3);
+        $client->setRetryDelay(3000);
+        $client->setRetryStatusCodes([401]);
+        $now = microtime(true);
+
+        $res = $client->fetch('localhost:8000/mock-retry-401');
+        $this->assertEquals(200, $res->getStatusCode());
+        $this->assertGreaterThan($now + 3.0, microtime(true));
+        unlink(__DIR__ . '/state.json');
+    }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -50,7 +50,7 @@ final class ResponseTest extends TestCase
         $jsonBody = \json_decode($body, true); // Convert JSON string to object
         $this->assertEquals($jsonBody, $resp->json()); // Assert that the JSON body is equal to the response's JSON body
         $bin = ""; // Convert string to binary
-        for($i = 0, $j = strlen($body); $i < $j; $i++) {
+        for ($i = 0, $j = strlen($body); $i < $j; $i++) {
             $bin .= decbin(ord($body)) . " ";
         }
         $this->assertEquals($bin, $resp->blob()); // Assert that the blob body is equal to the response's blob body

--- a/tests/router.php
+++ b/tests/router.php
@@ -71,6 +71,20 @@ if ($curPageName == 'image') {
         'success' => true,
         'attempts' => $state['attempts']
     ]);
+} elseif ($curPageName == 'mock-retry-401') {
+    $state = getState();
+    $state['attempts'] = isset($state['attempts']) ? $state['attempts'] + 1 : 1;
+    setState($state);
+
+    if ($state['attempts'] <= 2) {
+        http_response_code(401);
+        throw new \Exception('Mock retry error');
+    }
+
+    $body = json_encode([
+        'success' => true,
+        'attempts' => $state['attempts']
+    ]);
 }
 $resp = [
   'method' => $method,

--- a/tests/router.php
+++ b/tests/router.php
@@ -9,17 +9,17 @@ $files = $_FILES; // Get the request files
 
 $curPageName = substr($_SERVER['REQUEST_URI'], strrpos($_SERVER['REQUEST_URI'], "/") + 1);
 
-if($curPageName == 'redirect') {
+if ($curPageName == 'redirect') {
     header('Location: http://localhost:8000/redirectedPage');
     exit;
 }
-if($curPageName == 'image') {
+if ($curPageName == 'image') {
     $filename = __DIR__."/resources/logo.png";
     header("Content-disposition: attachment;filename=$filename");
     header("Content-type: application/octet-stream");
     readfile($filename);
     exit;
-} elseif($curPageName == 'text') {
+} elseif ($curPageName == 'text') {
     $filename = __DIR__."/resources/test.txt";
     header("Content-disposition: attachment;filename=$filename");
     header("Content-type: application/octet-stream");

--- a/tests/router.php
+++ b/tests/router.php
@@ -7,6 +7,23 @@ $headers = getallheaders(); // Get request headers
 $body = file_get_contents("php://input"); // Get the request body
 $files = $_FILES; // Get the request files
 
+$stateFile = __DIR__ . '/state.json';
+
+function getState()
+{
+    global $stateFile;
+    if (file_exists($stateFile)) {
+        return json_decode(file_get_contents($stateFile), true) ?? [];
+    }
+    return [];
+}
+
+function setState($newState)
+{
+    global $stateFile;
+    file_put_contents($stateFile, json_encode($newState, JSON_PRETTY_PRINT));
+}
+
 $curPageName = substr($_SERVER['REQUEST_URI'], strrpos($_SERVER['REQUEST_URI'], "/") + 1);
 
 if ($curPageName == 'redirect') {
@@ -25,6 +42,20 @@ if ($curPageName == 'image') {
     header("Content-type: application/octet-stream");
     readfile($filename);
     exit;
+} elseif ($curPageName == 'mock-retry') {
+    $state = getState();
+    $state['attempts'] = isset($state['attempts']) ? $state['attempts'] + 1 : 1;
+    setState($state);
+
+    if ($state['attempts'] <= 2) {
+        http_response_code(503);
+        throw new \Exception('Mock retry error');
+    }
+
+    $body = json_encode([
+        'success' => true,
+        'attempts' => $state['attempts']
+    ]);
 }
 $resp = [
   'method' => $method,

--- a/tests/router.php
+++ b/tests/router.php
@@ -9,16 +9,31 @@ $files = $_FILES; // Get the request files
 
 $stateFile = __DIR__ . '/state.json';
 
-function getState()
+/**
+ * Get the state from the state file
+ * @return array<string, mixed>
+ */
+function getState(): array
 {
     global $stateFile;
     if (file_exists($stateFile)) {
-        return json_decode(file_get_contents($stateFile), true) ?? [];
+        $data = file_get_contents($stateFile);
+
+        if ($data === false) {
+            throw new \Exception('Failed to read state file');
+        }
+
+        return json_decode($data, true) ?? [];
     }
     return [];
 }
 
-function setState($newState)
+/**
+ * Set the state to the state file
+ * @param array<string, mixed> $newState
+ * @return void
+ */
+function setState(array $newState): void
 {
     global $stateFile;
     file_put_contents($stateFile, json_encode($newState, JSON_PRETTY_PRINT));


### PR DESCRIPTION
This PR adds retry functionality to the fetch client; by default, it is disabled, and `maxRetries` is set to 0. 

If maxRetries is set to a non-0 value, the code will automatically retry requests that fail with either a 500 or 503 value up to the number of maxRetries. If the response is still 500/503, it will then return that response.