### PR TITLE
Fix form urlencoded request bodies

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -313,7 +313,8 @@ class Client
         if (is_array($body) && isset($this->headers['content-type'])) {
             $body = match ($this->headers['content-type']) {
                 self::CONTENT_TYPE_APPLICATION_JSON => $this->jsonEncode($body),
-                self::CONTENT_TYPE_APPLICATION_FORM_URLENCODED, self::CONTENT_TYPE_MULTIPART_FORM_DATA => self::flatten($body),
+                self::CONTENT_TYPE_APPLICATION_FORM_URLENCODED => http_build_query($body),
+                self::CONTENT_TYPE_MULTIPART_FORM_DATA => self::flatten($body),
                 self::CONTENT_TYPE_GRAPHQL => isset($body['query']) && is_string($body['query']) ? $body['query'] : $this->jsonEncode($body),
                 default => $body,
             };

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -130,6 +130,36 @@ final class ClientTest extends TestCase
             echo "Please configure your PHP inbuilt SERVER";
         }
     }
+
+    public function testFormUrlencodedArrayBody(): void
+    {
+        $client = new Client();
+        $client->addHeader('content-type', Client::CONTENT_TYPE_APPLICATION_FORM_URLENCODED);
+
+        $resp = $client->fetch(
+            url: '127.0.0.1:8000',
+            method: Client::METHOD_POST,
+            body: [
+                'grant_type' => 'client_credentials',
+                'client_id' => 'client id',
+                'client_secret' => 'client+secret',
+                'scope' => [
+                    'mailbox',
+                    'conversation',
+                ],
+            ],
+        );
+
+        $this->assertSame(200, $resp->getStatusCode());
+        $respData = $resp->json();
+
+        $this->assertIsArray($respData);
+        $this->assertSame(
+            'grant_type=client_credentials&client_id=client+id&client_secret=client%2Bsecret&scope%5B0%5D=mailbox&scope%5B1%5D=conversation',
+            $respData['body']
+        );
+    }
+
     /**
      * Test for sending a file in the request body
      * @dataProvider sendFileDataSet


### PR DESCRIPTION
## Summary

- encode `application/x-www-form-urlencoded` array bodies with `http_build_query()` before sending
- keep multipart bodies as flattened arrays for file/form uploads
- add a regression test that asserts the raw form-urlencoded request body

## Context

`CURLOPT_POSTFIELDS` treats an array body differently from a URL-encoded string. OAuth-style endpoints that expect `application/x-www-form-urlencoded` payloads require a raw query-string body, for example `grant_type=client_credentials&client_id=...`.

## Test Plan

- `php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpunit --filter testFormUrlencodedArrayBody`
- `php -d error_reporting='E_ALL & ~E_DEPRECATED' vendor/bin/phpunit tests/ClientTest.php`
- `vendor/bin/pint --test --config pint.json src/Client.php tests/ClientTest.php`
