### PR TITLE
Remove deprecated curl_close calls

### DIFF
--- a/src/Adapter/Curl.php
+++ b/src/Adapter/Curl.php
@@ -187,7 +187,6 @@ class Curl implements Adapter
     public function __destruct()
     {
         if ($this->handle !== null) {
-            curl_close($this->handle);
             $this->handle = null;
         }
     }


### PR DESCRIPTION
## What does this PR do?

Removes calls to `curl_close()`. Since PHP 8.0, cURL handles are `CurlHandle` objects and `curl_close()` no longer has an effect; handles are released by object lifetime instead. Removing these calls avoids noisy PHP 8.5 deprecation warnings without changing behavior for supported PHP versions.

## Test Plan

- Ran `php -l` on changed PHP files where applicable.
- Confirmed no `curl_close(...)` calls remain in this repository.

## Related PRs and Issues

N/A

### Have you read the Contributing Guidelines on issues?

Yes.
