### PR TITLE
fix: break CurlHandle reference cycle leaking connections

### DIFF
--- a/src/Adapter/Curl.php
+++ b/src/Adapter/Curl.php
@@ -125,7 +125,7 @@ class Curl implements Adapter
             CURLOPT_URL => $url,
             CURLOPT_HTTPHEADER => $formattedHeaders,
             CURLOPT_CUSTOMREQUEST => $method,
-            CURLOPT_HEADERFUNCTION => function ($curl, $header) use (&$responseHeaders) {
+            CURLOPT_HEADERFUNCTION => static function ($curl, $header) use (&$responseHeaders) {
                 $len = strlen($header);
                 $header = explode(':', $header, 2);
                 if (count($header) < 2) {
@@ -134,7 +134,7 @@ class Curl implements Adapter
                 $responseHeaders[strtolower(trim($header[0]))] = trim($header[1]);
                 return $len;
             },
-            CURLOPT_WRITEFUNCTION => function ($ch, $data) use ($chunkCallback, &$responseBody, &$chunkIndex) {
+            CURLOPT_WRITEFUNCTION => static function ($ch, $data) use ($chunkCallback, &$responseBody, &$chunkIndex) {
                 if ($chunkCallback !== null) {
                     $chunk = new Chunk(
                         data: $data,


### PR DESCRIPTION
## Problem

`Curl::send()` registers the header and write callbacks as non-static closures. Closures declared in an instance method bind `$this`, and `curl_setopt` stores them on the `CurlHandle` — which the adapter itself holds:

```
adapter → CurlHandle → closure → adapter
```

This reference cycle keeps the handle alive after the last external reference to the `Client` is dropped, so `__destruct` (and its `curl_close`) only runs when PHP's cycle collector fires — by default after 10,000 cycle roots accumulate. Until then, every request from a fresh `Client` leaks an open keep-alive connection: **2 fds and ~1MB of native TLS buffers per request**, invisible to `memory_get_usage()`.

In long-running processes (Swoole workers) doing per-request `new Client()`, this is catastrophic: we traced an hourly OOMKill of Appwrite Cloud's billing aggregation worker to exactly this — a single worker child held 400+ ESTABLISHED TLS connections and >100MB of native memory mid-job.

## Measurements (150 sequential requests, one process)

| | fds | private-dirty RSS |
|---|---|---|
| before | 309 (grows +2/req) | 183MB (grows ~1MB/req) |
| after (static closures) | 9 (flat) | 31MB (flat) |

## Fix

Mark both callbacks `static` — neither uses `$this`, so this is behavior-preserving and simply prevents the binding that forms the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)